### PR TITLE
[WIP] Add variable for limiting clients

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,15 @@ ntp_servers:
   - 1.pool.ntp.org
   - 2.pool.ntp.org
   - 3.pool.ntp.org
+
+# NTP clients that are allowed to query this server. If non-empty, this host is
+# assumed to be an NTP server itself.
+#
+# Example:
+#
+#ntp_clients:
+#  - ip4addr: 1.2.3.0
+#    ip4mask: 255.255.255.0
+#  - ip4addr: 4.3.2.64
+#    ip4mask: 255.255.255.240
+ntp_clients: []

--- a/templates/etc/ntp.conf.j2
+++ b/templates/etc/ntp.conf.j2
@@ -23,6 +23,11 @@ filegen clockstats file clockstats type day enable
 server {{ server }} iburst
 {% endfor %}
 
+{% if ntp_clients|count > 0 %}
+# We are a server, too
+server 127.127.1.0
+{% endif %}
+
 # Fudge local clock if time servers are not available
 fudge 127.127.1.0 stratum 10
 
@@ -34,9 +39,17 @@ fudge 127.127.1.0 stratum 10
 # that might be intended to block requests from certain clients could also end
 # up blocking replies from your own upstream servers.
 
+{% if ntp_clients|count == 0 %}
 # By default, exchange time with everybody, but don't allow configuration.
 restrict -4 default kod notrap nomodify nopeer noquery
 restrict -6 default kod notrap nomodify nopeer noquery
+{% else %}
+# Only allow selected IP ranges.
+restrict default nomodify notrap
+{% for client in ntp_clients %}
+restrict {{ client.ip4addr }} mask {{ client.ip4mask }} nomodify notrap
+{% endfor %}
+{% endif %}
 
 # Local users may interrogate the ntp server more closely.
 restrict 127.0.0.1


### PR DESCRIPTION
##### SUMMARY

These changes add a way for limiting the hosts that are allowed to use the configured host as an NTP server.

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ayekat/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Jul 16 2019, 07:12:58) [GCC 9.1.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

There is now a new variable `ntp_clients`, which encodes a list.

If the list is empty (the default), the behaviour is unchanged. If the list is non-empty, `/etc/ntp.conf` will be generated such that only the hosts described in the list are allowed to synchronise (and query) this host.

Each host is described by `ip4addr` and `ip4mask`, for describing the IPv4 address and network mask.

An example variable configuration may look like this:

```
---

ntp_clients:
  - ip4addr: 1.2.3.0
    ip4mask: 255.255.255.0
  - ip4addr: 4.3.2.64
    ip4mask: 255.255.255.240
```

#### To Do

Currently this only support IPv4. It may be reasonable to extend this to IPv6 before merging (or at least open a separate issue/MR).